### PR TITLE
Remove usage of undefined functions

### DIFF
--- a/HM/Sniffs/Performance/SlowMetaQuerySniff.php
+++ b/HM/Sniffs/Performance/SlowMetaQuerySniff.php
@@ -4,6 +4,7 @@ namespace HM\Sniffs\Performance;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\AbstractArrayAssignmentRestrictionsSniff;
 
 /**
@@ -138,7 +139,7 @@ class SlowMetaQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 
 		foreach ( $elements as $element ) {
 			if ( isset( $element['index_start'] ) ) {
-				$index = $this->strip_quotes( $this->tokens[ $element['index_start'] ]['content'] );
+				$index = TextStrings::stripQuotes( $this->tokens[ $element['index_start'] ]['content'] );
 				if ( strtolower( $index ) === 'relation' ) {
 					// Skip 'relation' element.
 					continue;
@@ -176,7 +177,7 @@ class SlowMetaQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 			return static::DYNAMIC_VALUE;
 		}
 
-		return $this->strip_quotes( $this->tokens[ $value_start ]['content'] );
+		return TextStrings::stripQuotes( $this->tokens[ $value_start ]['content'] );
 	}
 
 	/**
@@ -208,7 +209,7 @@ class SlowMetaQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
 				continue;
 			}
 
-			$index = $this->strip_quotes( $this->tokens[ $start ]['content'] );
+			$index = TextStrings::stripQuotes( $this->tokens[ $start ]['content'] );
 			if ( $index !== $array_key ) {
 				// Not the item we want, skip.
 				continue;

--- a/HM/Sniffs/Security/ValidatedSanitizedInputSniff.php
+++ b/HM/Sniffs/Security/ValidatedSanitizedInputSniff.php
@@ -4,6 +4,7 @@ namespace HM\Sniffs\Security;
 
 use HM\Sniffs\ExtraSniffCode;
 use PHP_CodeSniffer\Files\File as PhpcsFile;
+use WordPressCS\WordPress\Helpers\VariableHelper;
 use WordPressCS\WordPress\Sniffs\Security\ValidatedSanitizedInputSniff as WPCSValidatedSanitizedInputSniff;
 
 class ValidatedSanitizedInputSniff extends WPCSValidatedSanitizedInputSniff {
@@ -71,7 +72,7 @@ class ValidatedSanitizedInputSniff extends WPCSValidatedSanitizedInputSniff {
 	 * @return bool True if this is a $_SERVER variable and is safe, false to run regular checks.
 	 */
 	protected function check_server_variable( $stackPtr ) {
-		$key = $this->get_array_access_key( $stackPtr );
+		$key = VariableHelper::get_array_access_key( $this->phpcsFile, $stackPtr );
 
 		// Find the next non-whitespace token.
 		$open_bracket = $this->phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );

--- a/HM/Sniffs/Security/ValidatedSanitizedInputSniff.php
+++ b/HM/Sniffs/Security/ValidatedSanitizedInputSniff.php
@@ -4,6 +4,7 @@ namespace HM\Sniffs\Security;
 
 use HM\Sniffs\ExtraSniffCode;
 use PHP_CodeSniffer\Files\File as PhpcsFile;
+use PHPCSUtils\Utils\TextStrings;
 use WordPressCS\WordPress\Helpers\VariableHelper;
 use WordPressCS\WordPress\Sniffs\Security\ValidatedSanitizedInputSniff as WPCSValidatedSanitizedInputSniff;
 
@@ -95,7 +96,7 @@ class ValidatedSanitizedInputSniff extends WPCSValidatedSanitizedInputSniff {
 		}
 
 		// Constant string, check if it's allowed.
-		$key = $this->strip_quotes( $this->tokens[ $index_token ]['content'] );
+		$key = TextStrings::stripQuotes( $this->tokens[ $index_token ]['content'] );
 		if ( ! in_array( $key, $this->allowedServerKeys, true ) ) {
 			// Unsafe key, requires sanitising.
 			return false;


### PR DESCRIPTION
Newer versions of WPCS use helper functions for various utility functions. Swap their usages to prevent undefined function errors.